### PR TITLE
Add missing store KeyReference for Order

### DIFF
--- a/types/order/Order.raml
+++ b/types/order/Order.raml
@@ -22,6 +22,8 @@ properties:
         email?: string
   anonymousId?:
     type: string
+  store?:
+    type: StoreKeyReference
   lineItems:
     type: LineItem[]
     (hasUpdateActions):


### PR DESCRIPTION
According to the documentation the Order has a store field just like the Cart object: https://docs.commercetools.com/http-api-projects-orders#order

Context: 
See #80 