### PR TITLE
Add missing detailedErrorMessage on InvalidJsonInputError

### DIFF
--- a/types/error/InvalidJsonInputError.raml
+++ b/types/error/InvalidJsonInputError.raml
@@ -5,3 +5,6 @@ type: ErrorObject
 
 displayName: InvalidJsonInputError
 discriminatorValue: InvalidJsonInput
+properties:
+    detailedErrorMessage?:
+        type: string


### PR DESCRIPTION
Adding the detailedErrorMessage allows us to expose more info on auto-generated api's