### PR TITLE
add missing search aribute

### DIFF
--- a/resources/product-projections-search.raml
+++ b/resources/product-projections-search.raml
@@ -19,6 +19,11 @@ get:
       description: |
         Provide explicitly the fuzzy level desired if fuzzy is enabled. This value can not be higher than the one
         chosen by the platform by default.
+    markMatchingVariants:
+      type: boolean
+      description: |
+        if `markMatchingVariants` parameter is `true` those ProductVariants that match the search query have the additional
+        field `isMatchingVariant` set to `true`. For the other variants in the same product projection this field is set to `false`.
     staged?:
       type: boolean
       description: Whether to query for the current or staged projections.


### PR DESCRIPTION
closes  #127

This adds a missing field `markMatchingVariants ` to product projection search