### PR TITLE
fixing return type for shipping methods

### DIFF
--- a/resources/in-store.raml
+++ b/resources/in-store.raml
@@ -920,10 +920,11 @@ uriParameters:
               - 'manage_customers:{projectKey}:{storeKey}'
               - 'view_shipping_methods:{projectKey}'
       queryParameters:
-        cartId?:
+        cartId:
           type: string
       responses:
         200:
           body:
             application/json:
+              type: ShippingMethodPagedQueryResponse
               example: !include ../examples/shipping-methods.example.json

--- a/resources/shipping-methods.raml
+++ b/resources/shipping-methods.raml
@@ -129,12 +129,13 @@ post:
           },
       ]
     queryParameters:
-      cartId?:
+      cartId:
         type: string
     responses:
       200:
         body:
           application/json:
+            type: ShippingMethodPagedQueryResponse
             example: !include ../examples/shipping-methods.example.json
 /matching-orderedit:
   type: base
@@ -163,6 +164,7 @@ post:
       200:
         body:
           application/json:
+            type: ShippingMethodPagedQueryResponse
             example: !include ../examples/shipping-methods.example.json
 /matching-location:
   type: base
@@ -193,6 +195,7 @@ post:
       200:
         body:
           application/json:
+            type: ShippingMethodPagedQueryResponse
             example: !include ../examples/shipping-methods.example.json
 /{ID}:
   (methodName): withId


### PR DESCRIPTION
The shipping methods endpoint are still missing some return types, this pr fixes the missing types.