### PR TITLE
Specify the correct uriParameter values for the custom object resource

### DIFF
--- a/resources/custom-objects.raml
+++ b/resources/custom-objects.raml
@@ -51,7 +51,11 @@ post:
   (methodName): withContainerAndKey
   type:
     baseResource:
-      uriParameterName: key
+      uriParameters:
+        container:
+          type: string
+        key:
+          type: string
       resourceType: CustomObject
   get:
     securedBy:
@@ -88,7 +92,7 @@ post:
   (methodName): withId
   type:
     baseResource:
-      uriParameterName: container
+      uriParameterName: ID
       resourceType: CustomObject
   get:
     securedBy:


### PR DESCRIPTION
For code generation we need to signal that the path takes two parameters (conatiner and key)