### PR TITLE
The fractionDigits field on Money is an optional value

### DIFF
--- a/api.swagger.json
+++ b/api.swagger.json
@@ -5718,7 +5718,6 @@
       },
       "required": [
         "type",
-        "fractionDigits",
         "centAmount",
         "currencyCode"
       ],

--- a/api.swagger3.json
+++ b/api.swagger3.json
@@ -26927,7 +26927,6 @@
         },
         "required": [
           "type",
-          "fractionDigits",
           "centAmount",
           "currencyCode"
         ],

--- a/types/common/TypedMoney.raml
+++ b/types/common/TypedMoney.raml
@@ -7,7 +7,7 @@ discriminator: type
 properties:
   type:
     type: MoneyType
-  fractionDigits:
+  fractionDigits?:
     type: number
     format: int32
     maximum: 12


### PR DESCRIPTION
According to the documentation the fractionDigits is optional and the
default value is based on the currency given.

See https://docs.commercetools.com/http-api-types.html#money

```
For money type it’s equal to the number of default fraction digits for a currency, can be omitted since it’s always equal to currency fraction digits.
```