### PR TITLE
removed warning about alpha version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # commercetools-api-reference
 Commercetools Platform API reference documentation
 
-:warning: Please note that this project is currently in the **ALPHA** version and is subject to change.
-
-
 [![Build Status](https://travis-ci.org/commercetools/commercetools-api-reference.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-api-reference)
 
 ## Postman


### PR DESCRIPTION
This project is already being used for generating SDKs that are live and is no more in alpha version.