### PR TITLE
Use correct type for Store.supplyChannels

### DIFF
--- a/types/store/Store.raml
+++ b/types/store/Store.raml
@@ -40,6 +40,6 @@ properties:
     description: |-
       Set of References to a Channel with `ProductDistribution` role
   supplyChannels?:
-    type: ChannelResourceIdentifier[]
+    type: ChannelReference[]
     description: |-
       Set of ResourceIdentifiers of Channels with `InventorySupply` role


### PR DESCRIPTION
According to the documentation (and tested via the api) the supplyChannel  should be a channelReference

See https://docs.commercetools.com/api/projects/stores#store