### PR TITLE
My Customer profile action updates

### DIFF
--- a/types/me/updates/MyCustomerAddAddressAction.raml
+++ b/types/me/updates/MyCustomerAddAddressAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#add-address
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#add-address
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerAddAddressAction

--- a/types/me/updates/MyCustomerAddBillingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerAddBillingAddressIdAction.raml
@@ -7,5 +7,7 @@ displayName: MyCustomerAddBillingAddressIdAction
 discriminatorValue: addBillingAddressId
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string

--- a/types/me/updates/MyCustomerAddBillingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerAddBillingAddressIdAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#add-billing-address-id
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#add-billing-address-id
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerAddBillingAddressIdAction

--- a/types/me/updates/MyCustomerAddShippingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerAddShippingAddressIdAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#add-shipping-address-id
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#add-shipping-address-id
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerAddShippingAddressIdAction

--- a/types/me/updates/MyCustomerAddShippingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerAddShippingAddressIdAction.raml
@@ -7,5 +7,7 @@ displayName: MyCustomerAddShippingAddressIdAction
 discriminatorValue: addShippingAddressId
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string

--- a/types/me/updates/MyCustomerChangeAddressAction.raml
+++ b/types/me/updates/MyCustomerChangeAddressAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#change-address
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#change-address
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerChangeAddressAction

--- a/types/me/updates/MyCustomerChangeAddressAction.raml
+++ b/types/me/updates/MyCustomerChangeAddressAction.raml
@@ -7,7 +7,9 @@ displayName: MyCustomerChangeAddressAction
 discriminatorValue: changeAddress
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string
   address:
     type: Address

--- a/types/me/updates/MyCustomerChangeEmailAction.raml
+++ b/types/me/updates/MyCustomerChangeEmailAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#change-email
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#change-email
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerChangeEmailAction

--- a/types/me/updates/MyCustomerRemoveAddressAction.raml
+++ b/types/me/updates/MyCustomerRemoveAddressAction.raml
@@ -7,5 +7,7 @@ displayName: MyCustomerRemoveAddressAction
 discriminatorValue: removeAddress
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string

--- a/types/me/updates/MyCustomerRemoveAddressAction.raml
+++ b/types/me/updates/MyCustomerRemoveAddressAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#remove-address
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#remove-address
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerRemoveAddressAction

--- a/types/me/updates/MyCustomerRemoveBillingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerRemoveBillingAddressIdAction.raml
@@ -7,5 +7,7 @@ displayName: MyCustomerRemoveBillingAddressIdAction
 discriminatorValue: removeBillingAddressId
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string

--- a/types/me/updates/MyCustomerRemoveBillingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerRemoveBillingAddressIdAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#remove-billing-address-id
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#remove-billing-address-id
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerRemoveBillingAddressIdAction

--- a/types/me/updates/MyCustomerRemoveShippingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerRemoveShippingAddressIdAction.raml
@@ -7,5 +7,7 @@ displayName: MyCustomerRemoveShippingAddressIdAction
 discriminatorValue: removeShippingAddressId
 
 properties:
-  addressId:
+  addressId?:
+    type: string
+  addressKey?:
     type: string

--- a/types/me/updates/MyCustomerRemoveShippingAddressIdAction.raml
+++ b/types/me/updates/MyCustomerRemoveShippingAddressIdAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#remove-shipping-address-id
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#remove-shipping-address-id
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerRemoveShippingAddressIdAction

--- a/types/me/updates/MyCustomerSetCompanyNameAction.raml
+++ b/types/me/updates/MyCustomerSetCompanyNameAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-company-name
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-company-name
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetCompanyNameAction

--- a/types/me/updates/MyCustomerSetCustomFieldAction.raml
+++ b/types/me/updates/MyCustomerSetCustomFieldAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-customfield
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-customfield
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetCustomFieldAction

--- a/types/me/updates/MyCustomerSetCustomTypeAction.raml
+++ b/types/me/updates/MyCustomerSetCustomTypeAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-custom-type
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-custom-type
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetCustomTypeAction

--- a/types/me/updates/MyCustomerSetDateOfBirthAction.raml
+++ b/types/me/updates/MyCustomerSetDateOfBirthAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-date-of-birth
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-date-of-birth
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetDateOfBirthAction

--- a/types/me/updates/MyCustomerSetDefaultBillingAddressAction.raml
+++ b/types/me/updates/MyCustomerSetDefaultBillingAddressAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-default-billing-address
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-default-billing-address
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetDefaultBillingAddressAction

--- a/types/me/updates/MyCustomerSetDefaultBillingAddressAction.raml
+++ b/types/me/updates/MyCustomerSetDefaultBillingAddressAction.raml
@@ -9,3 +9,5 @@ discriminatorValue: setDefaultBillingAddress
 properties:
   addressId?:
     type: string
+  addressKey?:
+    type: string

--- a/types/me/updates/MyCustomerSetDefaultShippingAddressAction.raml
+++ b/types/me/updates/MyCustomerSetDefaultShippingAddressAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-default-shipping-address
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-default-shipping-address
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetDefaultShippingAddressAction

--- a/types/me/updates/MyCustomerSetDefaultShippingAddressAction.raml
+++ b/types/me/updates/MyCustomerSetDefaultShippingAddressAction.raml
@@ -9,3 +9,5 @@ discriminatorValue: setDefaultShippingAddress
 properties:
   addressId?:
     type: string
+  addressKey?:
+    type: string

--- a/types/me/updates/MyCustomerSetFirstNameAction.raml
+++ b/types/me/updates/MyCustomerSetFirstNameAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-first-name
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-first-name
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetFirstNameAction

--- a/types/me/updates/MyCustomerSetLastNameAction.raml
+++ b/types/me/updates/MyCustomerSetLastNameAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-last-name
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-last-name
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetLastNameAction

--- a/types/me/updates/MyCustomerSetLocaleAction.raml
+++ b/types/me/updates/MyCustomerSetLocaleAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-locale
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-locale
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetLocaleAction

--- a/types/me/updates/MyCustomerSetMiddleNameAction.raml
+++ b/types/me/updates/MyCustomerSetMiddleNameAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-middle-name
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-middle-name
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetMiddleNameAction

--- a/types/me/updates/MyCustomerSetSalutationAction.raml
+++ b/types/me/updates/MyCustomerSetSalutationAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-salutation
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-salutation
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetSalutationAction

--- a/types/me/updates/MyCustomerSetTitleAction.raml
+++ b/types/me/updates/MyCustomerSetTitleAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-title
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-title
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetTitleAction

--- a/types/me/updates/MyCustomerSetVatIdAction.raml
+++ b/types/me/updates/MyCustomerSetVatIdAction.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 (package): Me
-(docs-uri): https://docs.commercetools.com/http-api-projects-customers.html#set-vat-id
+(docs-uri): https://docs.commercetools.com/http-api-projects-me-profile.html#set-vat-id
 
 type: MyCustomerUpdateAction
 displayName: MyCustomerSetVatIdAction


### PR DESCRIPTION
I noticed some types were behind on the documentation for my profile. In particular, the address update actions did not allow for [Address selection](https://docs.commercetools.com/api/projects/me-profile#address-selection). In addition, the docs-uri fields for these files were incorrect.

I'm not sure if these are the files to edit, or if this is again generated from elsewhere. Let me know if this contribution should be in a different form!