### PR TITLE
addition of required for TypedMoneyDraft,Message, and TypeResourceIde…

### DIFF
--- a/types/common/TypedMoneyDraft.raml
+++ b/types/common/TypedMoneyDraft.raml
@@ -4,6 +4,7 @@
 displayName: TypedMoneyDraft
 type: Money
 discriminator: type
+required: ["type"]
 properties:
   type:
     type: MoneyType

--- a/types/message/Message.raml
+++ b/types/message/Message.raml
@@ -3,6 +3,7 @@
 (docs-uri): https://docs.commercetools.com/http-api-projects-messages.html#message
 type: BaseResource
 displayName: Message
+required: ["type"]
 discriminator: type
 (java-extends): 'com.commercetools.api.models.DomainResource<Message>'
 properties:

--- a/types/type/TypeResourceIdentifier.raml
+++ b/types/type/TypeResourceIdentifier.raml
@@ -4,3 +4,5 @@
 type: ResourceIdentifier
 displayName: TypeResourceIdentifier
 discriminatorValue: type
+required: ["typeId"]
+


### PR DESCRIPTION
…ntifier

Tiffany worked with Microsoft to get the swagger file to import into Azure. Three changes were made, the addition of type for TypedMoneyDraft, Message, and ResourceIdentifier. See https://github.com/commercetools/commercetools-api-reference/issues/198

Is the following syntax correct for adding to the api reference?