### PR TITLE
The facets property is only available on the ProductProjectionPagedQueryResponse

### DIFF
--- a/api-specs/api/types/PagedQueryResponse.raml
+++ b/api-specs/api/types/PagedQueryResponse.raml
@@ -19,7 +19,5 @@ properties:
     format: int64
   results:
     type: BaseResource[]
-  facets?:
-    type: FacetResults
   meta?:
     type: object

--- a/api-specs/api/types/product/ProductProjectionPagedQueryResponse.raml
+++ b/api-specs/api/types/product/ProductProjectionPagedQueryResponse.raml
@@ -18,3 +18,5 @@ properties:
     format: int64
   results:
     type: ProductProjection[]
+  facets?:
+    type: FacetResults

--- a/api.swagger.json
+++ b/api.swagger.json
@@ -32469,11 +32469,6 @@
           "x-annotation-builtinType": "array",
           "x-annotation-inherited": false
         },
-        "facets": {
-          "$ref": "#/definitions/FacetResults",
-          "x-annotation-builtinType": "object",
-          "x-annotation-inherited": false
-        },
         "meta": {
           "type": "object",
           "x-annotation-builtinType": "object",
@@ -39124,6 +39119,11 @@
             "$ref": "#/definitions/ProductProjection"
           },
           "x-annotation-builtinType": "array",
+          "x-annotation-inherited": false
+        },
+        "facets": {
+          "$ref": "#/definitions/FacetResults",
+          "x-annotation-builtinType": "object",
           "x-annotation-inherited": false
         }
       },

--- a/api.swagger3.json
+++ b/api.swagger3.json
@@ -58712,11 +58712,6 @@
             "x-annotation-builtinType": "array",
             "x-annotation-inherited": false
           },
-          "facets": {
-            "$ref": "#/components/schemas/FacetResults",
-            "x-annotation-builtinType": "object",
-            "x-annotation-inherited": false
-          },
           "meta": {
             "type": "object",
             "x-annotation-builtinType": "object",
@@ -65061,6 +65056,11 @@
               "$ref": "#/components/schemas/ProductProjection"
             },
             "x-annotation-builtinType": "array",
+            "x-annotation-inherited": false
+          },
+          "facets": {
+            "$ref": "#/components/schemas/FacetResults",
+            "x-annotation-builtinType": "object",
             "x-annotation-inherited": false
           }
         },

--- a/oas/gen.properties
+++ b/oas/gen.properties
@@ -1,1 +1,1 @@
-hash=03d2e184d464dc96a1be65fdeb5dd4d6a4289ccd
+hash=0c8460dd79fd0ddf160d4016face9b0d1afdce63

--- a/postman/gen.properties
+++ b/postman/gen.properties
@@ -1,1 +1,1 @@
-hash=03d2e184d464dc96a1be65fdeb5dd4d6a4289ccd
+hash=0c8460dd79fd0ddf160d4016face9b0d1afdce63


### PR DESCRIPTION

This solves the issue with code generation where a base class
is relying on functionality of a specific sub resource (cyclic imports)