### PR TITLE
feat: add deleteDaysAfterLastModification field to api spec for project type

### DIFF
--- a/api-specs/api/types/project/CartsConfiguration.raml
+++ b/api-specs/api/types/project/CartsConfiguration.raml
@@ -10,7 +10,8 @@ properties:
       address state is not explicitly covered in the rates lists of all tax
       categories of a cart line items. Default value 'false'
   deleteDaysAfterLastModification?:
-    type: int64
+    type: number
+    format: int64
     description:
       The default value for the deleteDaysAfterLastModification parameter of the
       CartDraft. Initially set to 90 for projects created after December 2019.

--- a/api-specs/api/types/project/CartsConfiguration.raml
+++ b/api-specs/api/types/project/CartsConfiguration.raml
@@ -9,3 +9,8 @@ properties:
       if country - no state tax rate fallback should be used when a shipping
       address state is not explicitly covered in the rates lists of all tax
       categories of a cart line items. Default value 'false'
+  deleteDaysAfterLastModification?:
+    type: int64
+    description:
+      The default value for the deleteDaysAfterLastModification parameter of the
+      CartDraft. Initially set to 90 for projects created after December 2019.

--- a/api-specs/api/types/project/updates/ProjectChangeCartConfiguration.raml
+++ b/api-specs/api/types/project/updates/ProjectChangeCartConfiguration.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+(package): Project
+(docs-uri): https://docs.commercetools.com/http-api-projects-project.html#change-carts-configuration
+type: ProjectUpdateAction
+displayName: ProjectChangeCartsConfiguration
+discriminatorValue: changeCartsConfiguration
+properties:
+  cartsConfiguration?:
+    type: CartsConfiguration
+    description: ''


### PR DESCRIPTION
The project type seems to be missing the deleteDaysAfterLastModification cart field