### PR TITLE
inventory-entry: Fix supportChannel type

### DIFF
--- a/api-specs/api/types/inventory/InventoryEntry.raml
+++ b/api-specs/api/types/inventory/InventoryEntry.raml
@@ -35,7 +35,7 @@ properties:
     type: string
     description: ''
   supplyChannel?:
-    type: ChannelResourceIdentifier
+    type: ChannelReference
     description: Optional connection to a particular supplier.
   quantityOnStock:
     type: number


### PR DESCRIPTION
The type of `supportChannel` is a `ChannelReference`, not a `ChannelResourceIdentifier`