### PR TITLE
Change CustomLineItemDraft to CustomLineItemImportDraft in OrderImpor…

### DIFF
--- a/api-specs/api/types/order/OrderImportDraft.raml
+++ b/api-specs/api/types/order/OrderImportDraft.raml
@@ -23,7 +23,7 @@ properties:
     type: LineItemImportDraft[]
   customLineItems?:
     description: If not given `lineItems` must not be empty.
-    type: CustomLineItemDraft[]
+    type: CustomLineItemImportDraft[]
   totalPrice:
     description: ''
     type: Money


### PR DESCRIPTION
…tDraft

Currently, `CustomLineItemDraft` is used in `OrderImportDraft` but `CustomLineItemDraft` doesn't have the `TaxRate` so it's not possible to have a custom line item with a tax rate. But in Commercetools, `CustomLineItemImportDraft` is used which has the `TaxRate`.

<img width="772" alt="Screen Shot 2021-07-03 at 9 48 03 AM" src="https://user-images.githubusercontent.com/31795824/124354212-1ee01c00-dc20-11eb-8072-43f6ced0bccd.png">