### PR TITLE
Add detailedErrorMessage to InvalidJsonInputError

### DIFF
--- a/api-specs/api/types/error/InvalidJsonInputError.raml
+++ b/api-specs/api/types/error/InvalidJsonInputError.raml
@@ -3,3 +3,6 @@
 type: ErrorObject
 displayName: InvalidJsonInputError
 discriminatorValue: InvalidJsonInput
+properties:
+  detailedErrorMessage?:
+    type: string


### PR DESCRIPTION
Currently `detailedErrorMessage` is returned by CommeceTools
Example:
```
{
   "statusCode":400,
   "message":"Request body does not contain valid JSON.",
   "errors":[
      {
         "code":"InvalidJsonInput",
         "message":"Request body does not contain valid JSON.",
         "detailedErrorMessage":"actions -> customerId: Invalid UUID: '62921'"
      }
   ]
}
```
However it is not included to the RAML file, which prevents autogenerated client to unmarshal its value. 

This PR adds the missed field