### PR TITLE
Update `removeLineItem quantity` Description in CartRemoveLineItemAction.raml

### DIFF
--- a/api-specs/api/types/cart/updates/CartRemoveLineItemAction.raml
+++ b/api-specs/api/types/cart/updates/CartRemoveLineItemAction.raml
@@ -20,7 +20,7 @@ properties:
     type: number
     format: int64
     description: |
-      New value to set.
+      Value to be decreased.
       If absent or `0`, the Line Item is removed from the Cart.
     minimum: 0
     default: 0


### PR DESCRIPTION
Hi,
Currently the docs say the `quantity` you provide in the `removeLineItem` Action is the new value that will be set for this LineItem. After testing, it looks as if the provided value is subtracted from the previous quantity. Is this correct?

![image](https://github.com/commercetools/commercetools-api-reference/assets/40147557/ae83bfe4-5767-40cb-8973-b212248fade8)

