### PR TITLE
Ignore custom environments in bruno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ composer.lock
 tmpdoc
 gen.properties
 
-/bruno/api/environments/*
-!/bruno/api/environments/DotEnv.bru
-!/bruno/api/environments/Example.bru
+/bruno/*/environments/*
+!/bruno/*/environments/DotEnv.bru
+!/bruno/*/environments/Example.bru

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ build
 composer.lock
 tmpdoc
 gen.properties
+
+/bruno/api/environments/*
+!/bruno/api/environments/DotEnv.bru
+!/bruno/api/environments/Example.bru


### PR DESCRIPTION
Since the environment files contains sensitive information they should be ignored